### PR TITLE
Integrate Mordecai geocoding service into pipeline

### DIFF
--- a/PHOX_config.ini
+++ b/PHOX_config.ini
@@ -7,7 +7,7 @@ server_dir = public_html/datasets/phoenix/
 [Geolocation]
 geo_service = Mordecai
 cliff_host = http://localhost
-cliff_port = 8999
+cliff_port = 8080
 mordecai_host = http://localhost
 mordecai_port = 5011
 

--- a/PHOX_config.ini
+++ b/PHOX_config.ini
@@ -3,8 +3,13 @@ server_name = <ftp site name>
 username = <user name>
 password = <password>
 server_dir = public_html/datasets/phoenix/
-cliff_host = localhost
+
+[Geolocation]
+geo_service = Mordecai
+cliff_host = http://localhost
 cliff_port = 8999
+mordecai_host = http://localhost
+mordecai_port = 5011
 
 [Pipeline]
 scraper_stem = scraper_results_
@@ -18,7 +23,7 @@ newsourcestem = newsources.
 oneaday_filter = True
 
 [Petrarch]
-petrarch_version = 1
+petrarch_version = 2
 
 #[Logging]
 #log_file = /root/logs/pipeline.log

--- a/geolocation.py
+++ b/geolocation.py
@@ -239,6 +239,10 @@ def query_mordecai(sentence, host, port):
     ----------
     sentence: String.
                 Text from which an event was coded.
+    host: String
+               Host where Mordecai is running (taken from config)
+    port: String
+               Port that Mordecai service is listening on 
     Returns
     -------
     lat: String.
@@ -259,6 +263,14 @@ def query_mordecai(sentence, host, port):
     out = requests.post(dest, data=data, headers=headers)
     return json.loads(out.text)
 
+def test_mordecai(sentence, host, port):
+    """
+    Check if Mordecai service is up and responding on given host and port.
+    Parameters
+    ----------
+    sentence: String.
+                Text from which an event was coded.
+    """
 
 def mordecai(events, file_details, server_details, geo_details):
     """
@@ -288,17 +300,13 @@ def mordecai(events, file_details, server_details, geo_details):
         query_text = sents[int(sentence_id)]
         geo_info = query_mordecai(query_text, geo_details.mordecai_host,
                                geo_details.mordecai_port)
-        print(geo_info)
         try:
             # temporary hack: take the first location:
             geo_info = geo_info[0]
             # NA is for ADM1, which mord doesn't return. See issue #2
             events[event]['geo'] = (geo_info['lon'], geo_info['lat'],
                               geo_info['placename'], "NA", geo_info['countrycode'])
-            print("worked")
         except Exception as e:
-            print("error")
-            print(e)
             events[event]['geo'] = ("NA", "NA", "NA", "NA", "NA")
 
     return events
@@ -325,7 +333,6 @@ def cliff(events, file_details, server_details, geo_details):
                                file_details.auth_pass)
 
     for event in events:
-        print(event)
         event_id, sentence_id = events[event]['ids'][0].split('_')
        # print(event_id)
         result = coll.find_one({'_id': ObjectId(event_id.split('_')[0])})

--- a/geolocation.py
+++ b/geolocation.py
@@ -34,7 +34,7 @@ def query_cliff(sentence, host, port):
     place_info = {'lat': '', 'lon': '', 'placeName': '', 'countryCode': '',
                   'stateName': '', 'restype' : ''}
 
-    cliff_address = "http://{}:{}/CLIFF-2.0.0/parse/text".format(host, port)
+    cliff_address = "{}:{}/CLIFF-2.0.0/parse/text".format(host, port)
     try:
         located = requests.get(cliff_address, params=payload).json()
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -12,6 +12,7 @@ import oneaday_filter
 import result_formatter
 import scraper_connection
 
+
 def main(file_details, geo_details, server_details, petrarch_version, logger_file=None, run_filter=None,
          run_date='', version=''):
     """
@@ -77,10 +78,6 @@ def main(file_details, geo_details, server_details, petrarch_version, logger_fil
                                                   process_date.day)
         logger.info('Date string: {}'.format(date_string))
         print('Date string:', date_string)
-    print("process date:")
-    print(process_date)
-    print("file_details")
-    print(file_details)
     results, scraperfilename = scraper_connection.main(process_date,
                                                        file_details)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -13,7 +13,7 @@ import result_formatter
 import scraper_connection
 #from petrarch2 import petrarch2
 
-server_details, file_details, petrarch_version = utilities.parse_config('PHOX_config.ini')
+server_details, geo_details, file_details, petrarch_version = utilities.parse_config('PHOX_config.ini')
 if petrarch_version == '1':
     from petrarch import petrarch
     print("Using original Petrarch version")
@@ -25,7 +25,7 @@ else:
 
 
 
-def main(file_details, server_details, logger_file=None, run_filter=None,
+def main(file_details, geo_details, server_details, logger_file=None, run_filter=None,
          run_date='', version=''):
     """
     Main function to run all the things.
@@ -35,6 +35,9 @@ def main(file_details, server_details, logger_file=None, run_filter=None,
 
     file_details: Named tuple.
                     All the other config information not in ``server_details``.
+
+    geo_details: Named tuple.
+                  Settings for geocoding.
 
     server_details: Named tuple.
                     Config information specifically related to the remote
@@ -77,7 +80,10 @@ def main(file_details, server_details, logger_file=None, run_filter=None,
                                                   process_date.day)
         logger.info('Date string: {}'.format(date_string))
         print('Date string:', date_string)
-
+    print("process date:")
+    print(process_date)
+    print("file_details")
+    print(file_details)
     results, scraperfilename = scraper_connection.main(process_date,
                                                        file_details)
 
@@ -89,7 +95,6 @@ def main(file_details, server_details, logger_file=None, run_filter=None,
     print("Running Mongo.formatter.py")
     formatted = formatter.main(results, file_details,
                                process_date, date_string)
-
     logger.info("Running PETRARCH")
     file_details.fullfile_stem + date_string
     if run_filter == 'False':
@@ -125,7 +130,7 @@ def main(file_details, server_details, logger_file=None, run_filter=None,
     print("Running postprocess.py")
     if version:
         postprocess.main(formatted_results, date_string, version, file_details,
-                         server_details)
+                         server_details, geo_details)
     else:
         print("Please specify a data version number. Program ending.")
 
@@ -143,7 +148,7 @@ def main(file_details, server_details, logger_file=None, run_filter=None,
 
 
 def run():
-    main(file_details, server_details, file_details.log_file,
+    main(file_details, geo_details, server_details, file_details.log_file,
          run_filter=file_details.oneaday_filter, version='v0.0.0')
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import sys
 import logging
+import requests
 import datetime
 import dateutil
 import uploader
@@ -80,6 +81,18 @@ def main(file_details, geo_details, server_details, petrarch_version, logger_fil
         print('Date string:', date_string)
     results, scraperfilename = scraper_connection.main(process_date,
                                                        file_details)
+    if geo_details.geo_service == "Mordecai":
+        dest = "{0}:{1}/places".format(geo_details.mordecai_host, geo_details.mordecai_port)
+        try:
+            out = requests.get(dest)
+            assert out.status_code == 200
+        except (AssertionError, requests.exceptions.ConnectionError):
+            print("Mordecai geolocation service not responding. Continuing anyway...")
+    elif geo_details.geo_service == "CLIFF":
+        print("CLIFF")
+    else:
+        print("Invalid geo service name. Must be 'CLIFF' or 'Mordecai'. Continuing...")
+
 
     if scraperfilename:
         logger.info("Scraper file name: " + scraperfilename)

--- a/pipeline.py
+++ b/pipeline.py
@@ -149,6 +149,5 @@ def run():
     main(file_details, geo_details, server_details, petrarch_version, file_details.log_file,
          run_filter=file_details.oneaday_filter, version='v0.0.0')
 
-
 if __name__ == '__main__':
     run()

--- a/pipeline.py
+++ b/pipeline.py
@@ -11,21 +11,8 @@ import postprocess
 import oneaday_filter
 import result_formatter
 import scraper_connection
-#from petrarch2 import petrarch2
 
-server_details, geo_details, file_details, petrarch_version = utilities.parse_config('PHOX_config.ini')
-if petrarch_version == '1':
-    from petrarch import petrarch
-    print("Using original Petrarch version")
-elif petrarch_version == '2':
-    from petrarch2 import petrarch2 as petrarch
-    print("Using Petrarch2")
-else:
-    print("Invalid Petrarch version. Argument must be '1' or '2'")
-
-
-
-def main(file_details, geo_details, server_details, logger_file=None, run_filter=None,
+def main(file_details, geo_details, server_details, petrarch_version, logger_file=None, run_filter=None,
          run_date='', version=''):
     """
     Main function to run all the things.
@@ -63,6 +50,16 @@ def main(file_details, geo_details, server_details, logger_file=None, run_filter
         utilities.init_logger('PHOX_pipeline.log')
     # get a local copy for the pipeline
     logger = logging.getLogger('pipeline_log')
+
+    if petrarch_version == '1':
+        from petrarch import petrarch
+        logger.info("Using original Petrarch version")
+    elif petrarch_version == '2':
+        from petrarch2 import petrarch2 as petrarch
+        logger.info("Using Petrarch2")
+    else:
+        logger.error("Invalid Petrarch version. Argument must be '1' or '2'")
+
 
     print('\nPHOX.pipeline run:', datetime.datetime.utcnow())
 
@@ -148,7 +145,8 @@ def main(file_details, geo_details, server_details, logger_file=None, run_filter
 
 
 def run():
-    main(file_details, geo_details, server_details, file_details.log_file,
+    server_details, geo_details, file_details, petrarch_version = utilities.parse_config('PHOX_config.ini')
+    main(file_details, geo_details, server_details, petrarch_version, file_details.log_file,
          run_filter=file_details.oneaday_filter, version='v0.0.0')
 
 

--- a/postprocess.py
+++ b/postprocess.py
@@ -358,7 +358,7 @@ def process_actors(event):
     return actors
 
 
-def main(event_dict, this_date, version, file_details, server_details):
+def main(event_dict, this_date, version, file_details, server_details, geo_details):
     """
     Pulls in the coded results from PETRARCH dictionary in the
     {StoryID: [(record), (record)]} format and allows only one unique
@@ -381,12 +381,23 @@ def main(event_dict, this_date, version, file_details, server_details):
     file_details: NamedTuple.
                     Container generated from the config file specifying file
                     stems and other relevant options.
+    server_details: NamedTuple.
+                    Info for uploading to server.
+    geo_details: NamedTuple.
+                    Info about geo type and geo server details.
     """
     logger = logging.getLogger('pipeline_log')
 
     logger.info('Geolocating.')
     print('Geolocating')
-    updated_events = geolocation.main(event_dict, file_details, server_details)
+    geo_details.geo_service == "Mordecai"
+    print(event_dict)
+    if geo_details.geo_service == "CLIFF":
+        updated_events = geolocation.cliff(event_dict, file_details, server_details, geo_details)
+    elif geo_details.geo_service == "Mordecai":
+        updated_events = geolocation.mordecai(event_dict, file_details, server_details, geo_details)
+    else:
+        print("Invalid geo service name. Must be 'CLIFF' or 'Mordecai'.")
 
     logger.info('Formatting events for output.')
     event_write = create_strings(updated_events, version)

--- a/postprocess.py
+++ b/postprocess.py
@@ -390,8 +390,6 @@ def main(event_dict, this_date, version, file_details, server_details, geo_detai
 
     logger.info('Geolocating.')
     print('Geolocating')
-    geo_details.geo_service == "Mordecai"
-    print(event_dict)
     if geo_details.geo_service == "CLIFF":
         updated_events = geolocation.cliff(event_dict, file_details, server_details, geo_details)
     elif geo_details.geo_service == "Mordecai":

--- a/utilities.py
+++ b/utilities.py
@@ -100,7 +100,6 @@ def parse_config(config_filename):
             log_file = ''
 
         petrarch_version = parser.get('Petrarch', 'petrarch_version')
-        print("petrarch version is {}".format(petrarch_version))
 
         file_attrs = namedtuple('FileAttributes', ['scraper_stem',
                                                    'recordfile_stem',

--- a/utilities.py
+++ b/utilities.py
@@ -32,6 +32,9 @@ def parse_config(config_filename):
                     Config information specifically related to the remote
                     server for FTP uploading.
 
+    geo_list : Named tuple.
+                 Config information for geocoding.
+
     file_list: Named tuple.
                 All the other config information not in ``server_list``.
 
@@ -47,17 +50,31 @@ def parse_config(config_filename):
         username = parser.get('Server', 'username')
         password = parser.get('Server', 'password')
         server_dir = parser.get('Server', 'server_dir')
-        cliff_host = parser.get('Server', 'cliff_host')
-        cliff_port = parser.get('Server', 'cliff_port')
 
         server_attrs = namedtuple('ServerAttributes', ['serv_name',
                                                        'username',
                                                        'password',
-                                                       'server_dir',
-                                                       'cliff_host',
-                                                       'cliff_port'])
+                                                       'server_dir'])
         server_list = server_attrs(serv_name, username, password,
-                                   server_dir, cliff_host, cliff_port)
+                                   server_dir)
+
+        geo_service = parser.get('Geolocation', 'geo_service')
+        cliff_host = parser.get('Geolocation', 'cliff_host')
+        cliff_port = parser.get('Geolocation', 'cliff_port')
+        mordecai_host = parser.get('Geolocation', 'mordecai_host')
+        mordecai_port = parser.get('Geolocation', 'mordecai_port')
+
+
+        geo_attrs = namedtuple('GeolocationAttributes', ['geo_service',
+                                                         'cliff_host',
+                                                         'cliff_port',
+                                                         'mordecai_host',
+                                                         'mordecai_port'
+                                                       ])
+
+        geo_list = geo_attrs(geo_service, cliff_host, cliff_port,
+                                     mordecai_host, mordecai_port)
+
 
         # these are listed in the order generated
         scraper_stem = parser.get('Pipeline', 'scraper_stem')
@@ -103,7 +120,7 @@ def parse_config(config_filename):
                                oneaday_filter, log_file, auth_db, auth_user,
                                auth_pass, db_host)
 
-        return server_list, file_list, petrarch_version
+        return server_list, geo_list, file_list, petrarch_version
     except Exception as e:
         print('Problem parsing config file. {}'.format(e))
 


### PR DESCRIPTION
The pipeline can now run with Mordecai for geocoding rather than CLIFF. The geolocation service can be selected in the config file.

Before merging, I need to:
- Check that nothing broke for CLIFF (need to run on a server that has CLIFF)
- Write unit tests once I'm sure nothing needs to change.
- Update the README.